### PR TITLE
Do not set content-length in a browser environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ METHOD_MAP = {
   'patch': 'patch'
 };
 
+var isServer = typeof window === 'undefined';
+
 module.exports = function(method, model, options) {
   var url = options.url || (typeof model.url == 'function' ? model.url() : model.url);
   var data = options.data || (method === 'create' || method === 'update' ? model.toJSON() : {});
@@ -20,7 +22,11 @@ module.exports = function(method, model, options) {
 
   // Inject POST/PUT data in body or GET data in querystring
   if (method == 'create' || method == 'update') {
-    req.send(data).set('content-length', JSON.stringify(data).length);
+      if(isServer) {
+          req.send(data).set('content-length', JSON.stringify(data).length);
+      } else {
+          req.send(data);
+      }
   } else {
     req.query(data);
   }


### PR DESCRIPTION
Browsers do not allow to set the content-length. If you try to do so Chrome throws the following error message:

Refused to set unsafe header "content-length"

According to the spec every browser has to terminate this step:
http://www.w3.org/TR/XMLHttpRequest/#the-setrequestheader()-method
