### PR TITLE
Fixes issues with multi-byte utf-8 characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,8 +9,6 @@ METHOD_MAP = {
   'patch': 'patch'
 };
 
-var isServer = typeof window === 'undefined';
-
 module.exports = function(method, model, options) {
   var url = options.url || (typeof model.url == 'function' ? model.url() : model.url);
   var data = options.data || (method === 'create' || method === 'update' ? model.toJSON() : {});


### PR DESCRIPTION
Using `JSON.stringify` to determine the `Content-Length` breaks when the data includes utf-8 multi-byte characters. The length only works in cases where the data only contains single byte characters. If any multi-byte characters are included it breaks. Superagent does the right thing, and uses `Buffer.byteLength()` if the `Content-Length` header is not specified.
