### PR TITLE
Make sure request objects get `.end`ed if they gets instantiated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbone-super-sync",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "Server-side Backbone.sync adapter using super agent.",
   "keywords": [
     "backbone",


### PR DESCRIPTION
Through arduous trial & error it seems that my issue in https://github.com/visionmedia/superagent/issues/339 was resolved by making sure if I instantiate a request object, that I definitely call `.end` on it. I believe the fact that request objects were instantiated and potentially not `.end`ed (because of the caching option in this module skipping the `.end`) caused some state to get wonky in superagent (losing the `this._callback`).
