### PR TITLE
Pass options to model.toJSON()

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = function(method, model, options) {
   var url = (options.url ||
     (typeof model.url == 'function' ? model.url() : model.url));
   var data = (options.data ||
-    (method === 'create' || method === 'update' ? model.toJSON() : {}));
+    (method === 'create' || method === 'update' ? model.toJSON(options) : {}));
   var deferred = Q.defer();
   var cacheClient = module.exports.cacheClient;
   var cacheTime = options.cacheTime || module.exports.defaultCacheTime;


### PR DESCRIPTION
Definitely surprised by why options weren't being passed through to `toJSON`. See https://github.com/jashkenas/backbone/blob/master/backbone.js#L1326