### PR TITLE
Latest memory leak related refactors

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,29 +9,6 @@ var Backbone = require('backbone');
 Backbone.sync = require('backbone-super-sync');
 ````
 
-## Adding to the Backbone.sync request
-
-Sometimes you need to add to the requests made by Backbone.sync, such as adding an XAPP token. Backbone Super Sync provides the method `editRequest` to intercept the super-agent request object before the request is made.
-
-**NOTE**: This is injected into _ALL_ server-side Backbone.sync calls. This behaves signifcantly different than when Backbone is used on the client. For instance you should not use this to add user-specific data to a request like an oauth access token or similar identifier where as on the client you might want to inject that kind of data sync-wide b/c the browser only represents one user.
-
-````javascript
-var Backbone = require('backbone');
-var superSync = require('backbone-super-sync');
-superSync.editRequest = function(req) {
-  req.set({ 'XAPP-TOKEN': 'foobar' });
-};
-Backbone.sync = superSync;
-````
-
-The arguments of Backbone.sync are also passed to editRequest in case you need to globally adjust the request based off `options` or otherwise.
-
-````javascript
-superSync.editRequest = function(req, method, model, options) {
-  req.set({ 'X-ACCESS-TOKEN': options.user.get('access_token') });
-};
-````
-
 ## Request timeouts
 
 By default Backbone super sync will timeout requests that take longer than 2 seconds. This is to avoid
@@ -86,6 +63,20 @@ new Backbone.Model({ id: 'cach-me' }).fetch({
 ````
 
 Use at your own risk—remember [there are only two hard things](http://martinfowler.com/bliki/TwoHardThings.html).
+
+## Modifying global Backbone.sync requests
+
+In the past there was a helper `superSync.editRequest = function(req) {}`. This has been deprecated. If you would like to modify sync-wide requests you can simply wrap Backbone.sync again. For example:
+
+````javascript
+var Backbone = require('backbone');
+var sync = Backbone.sync = require('backbone-super-sync');
+
+Backbone.sync = function(method, model, options) {
+  options.headers['x-xapp-token'] = 'foobar';
+  return sync(method, model, options);
+}
+```` 
 
 ## Contributing
 

--- a/index.js
+++ b/index.js
@@ -74,10 +74,9 @@ var send = function (method, model, options, resolve, reject) {
   // Allow intercepting of the request object to inject sync-wide things like
   // an oAuth token.
   // module.exports.editRequest(req, method, model, options);
-
   request[METHOD_MAP[method]](url)
-    .send(method == 'create' || method == 'update' ? data : {})
-    .query(method == 'create' || method == 'update' ? {} : data)
+    .send(method == 'create' || method == 'update' ? data : null)
+    .query(method == 'create' || method == 'update' ? null : data)
     .set(options.headers || {})
     .timeout(options.timeout || module.exports.timeout)
     .end(function(err, res) {

--- a/index.js
+++ b/index.js
@@ -76,8 +76,8 @@ var send = function (method, model, options, resolve, reject) {
   // module.exports.editRequest(req, method, model, options);
 
   module.exports.editRequest(request[METHOD_MAP[method]](url)
-    .send(data)
-    .query(data)
+    .send(method == 'create' || method == 'update' ? data : {})
+    .query(method == 'create' || method == 'update' ? {} : data)
     .set(options.headers || {})
     .timeout(options.timeout || module.exports.timeout)
     .end(function(err, res) {

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ var send = function (method, model, options, resolve, reject) {
   // an oAuth token.
   // module.exports.editRequest(req, method, model, options);
 
-  module.exports.editRequest(request[METHOD_MAP[method]](url)
+  request[METHOD_MAP[method]](url)
     .send(method == 'create' || method == 'update' ? data : {})
     .query(method == 'create' || method == 'update' ? {} : data)
     .set(options.headers || {})
@@ -91,7 +91,7 @@ var send = function (method, model, options, resolve, reject) {
           (options.cacheTime || module.exports.defaultCacheTime));
       }
       success(options, res, resolve);
-    }), method, model, options);
+    });
   model.trigger('request', model, {});
 }
 

--- a/index.js
+++ b/index.js
@@ -73,7 +73,6 @@ var send = function (method, model, options, resolve, reject) {
 
   // Allow intercepting of the request object to inject sync-wide things like
   // an oAuth token.
-  // module.exports.editRequest(req, method, model, options);
   request[METHOD_MAP[method]](url)
     .send(method == 'create' || method == 'update' ? data : null)
     .query(method == 'create' || method == 'update' ? null : data)
@@ -121,11 +120,10 @@ var error = function(options, err, reject) {
   reject(err);
 }
 
-// Configuration that can be overwritten by the user. Includes being able
-// to modify the request, a cache client library, default cache expiry, and
+// Configuration that can be overwritten by the user. Includes a optional
+// cache client library integration, default cache expiry, and
 // the default timeout for a sent http request.
 
-module.exports.editRequest = function(req) {};
 module.exports.cacheClient = null;
 module.exports.defaultCacheTime = 3600;
 module.exports.timeout = 2000;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbone-super-sync",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Server-side Backbone.sync adapter using super agent.",
   "keywords": [
     "backbone",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbone-super-sync",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "description": "Server-side Backbone.sync adapter using super agent.",
   "keywords": [
     "backbone",

--- a/test.js
+++ b/test.js
@@ -102,18 +102,6 @@ describe('Backbone Super Sync', function() {
       });
     });
 
-    it('passes the Backbone.sync arguments to editRequest', function(done) {
-      superSync.editRequest = function(req, method, model, options) {
-        options.foo.should.equal('bar');
-        superSync.editRequest = function(){};
-        done();
-      }
-      model.fetch({
-        url: 'http://localhost:5000/custom/url',
-        foo: 'bar'
-      });
-    });
-
     it('can get the headers', function(done) {
       model.fetch({
         url: 'http://localhost:5000/headers',

--- a/test.js
+++ b/test.js
@@ -10,6 +10,16 @@ app.use(function(req, res, next) {
   requestCount++;
   next();
 });
+app.get('/raw/body', function(req, res, next) {
+  lastRequest = req;
+  req.rawBody = '';
+  req.on('data', function(chunk) {
+    req.rawBody += chunk;
+  });
+  req.on('end', function() {
+    res.send({ foo: 'bar' });
+  });
+});
 app.use(bodyParser());
 app.all('/foo/bar', function(req, res) {
   lastRequest = req;
@@ -152,6 +162,16 @@ describe('Backbone Super Sync', function() {
         timeout: 10,
         error: function(m, err) {
           err.message.should.containEql('timeout of 10ms');
+          done();
+        }
+      });
+    });
+
+    it('does not send empty body params', function(done) {
+      model.url = 'http://localhost:5000/raw/body';
+      model.fetch({
+        success: function(m, err) {
+          lastRequest.rawBody.length.should.equal(0)
           done();
         }
       });
@@ -310,6 +330,16 @@ describe('Backbone Super Sync', function() {
         foo: 'moo',
         success: function() {
           lastRequest.body.foo.should.equal('moo');
+          done();
+        }
+      });
+    });
+
+    it('does not send empty query params', function(done) {
+      model.url = 'http://localhost:5000/foo/bar'
+      model.save({}, {
+        success: function(m, err) {
+          Object.keys(lastRequest.query).length.should.equal(0);
           done();
         }
       });


### PR DESCRIPTION
Got a flat memory graph on vanilla Ezel project for 12hrs of pinging with this implementation. `editRequest` is an odd feature anyways—so updating docs, breaking version, and some refactored implementation.

![image](https://cloud.githubusercontent.com/assets/555859/9361780/22ccbd38-466b-11e5-9d30-e7eaf31cc471.png)

