### PR TITLE
Use bluebird.js instead of Q

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ By default Backbone super sync will timeout requests that take longer than 10 se
 long hanging requests that can potentionally leak memory. You can set this to be longer for all requests, e.g.
 
 ````javascript
-superSync.timeout = 5000; // All requests timeout after 5 seconds
+superSync.timeout = 60000; // All requests timeout after 1 minute
 ````
 
 ...or you can set this per-request by specifying it in options, e.g.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Backbone.sync = require('backbone-super-sync');
 
 ## Request timeouts
 
-By default Backbone super sync will timeout requests that take longer than 2 seconds. This is to avoid
+By default Backbone super sync will timeout requests that take longer than 10 seconds. This is to avoid
 long hanging requests that can potentionally leak memory. You can set this to be longer for all requests, e.g.
 
 ````javascript
@@ -76,7 +76,7 @@ Backbone.sync = function(method, model, options) {
   options.headers['x-xapp-token'] = 'foobar';
   return sync(method, model, options);
 }
-```` 
+````
 
 ## Contributing
 

--- a/index.js
+++ b/index.js
@@ -68,7 +68,6 @@ module.exports = function(method, model, options) {
     } else {
       send();
     }
-    // model.trigger('request', model, {}, options);
   });
 }
 

--- a/index.js
+++ b/index.js
@@ -12,118 +12,76 @@ var METHOD_MAP = {
 // Main exported sync function. Returns a Q promise to mimic Backbone + jQuery,
 // if using the built in cache support it will check the cache for data or send
 // off the HTTP request.
-//
-// @param {Function} method
-// @param {Object} model
-// @param {Object} options
-// @return {Object} A Q promise to mimc how Backbone work with jQuery
-
 module.exports = function(method, model, options) {
-  var cacheKey = urlDataCacheKey(method, model, options)[2];
-  var deferred = Q.defer();
-  if (options.cache && module.exports.cacheClient) {
-    module.exports.cacheClient.get(cacheKey, function(err, cachedJSON) {
-      if (err || cachedJSON) model.trigger('request', model, {}, options);
-      if (err) {
-        error(options, err, deferred.reject);
-      } else if (cachedJSON) {
-        success(options, JSON.parse(cachedJSON), deferred.resolve);
-      } else {
-        send(method, model, options, deferred.resolve, deferred.reject);
-      }
-    });
-  } else {
-    send(method, model, options, deferred.resolve, deferred.reject);
-  }
-  return deferred.promise.fin(function() {
-    deferred = null;
-  });
-};
-
-// Helper to compute the requesting url, params, and cache key based off those
-// two. Used when sending a new http request or determing the cache key to read.
-//
-// @param {Function} method
-// @param {Object} model
-// @param {Object} options
-// @return {Array} Array of [url, data, cacheKey]
-
-var urlDataCacheKey = function(method, model, options) {
   var url = (options.url ||
     (typeof model.url == 'function' ? model.url() : model.url));
   var data = (options.data ||
     (method === 'create' || method === 'update' ? model.toJSON(options) : {}));
   var cacheKey = url + JSON.stringify(data);
-  return [url, data, cacheKey];
-}
+  var dfd = Q.defer();
 
-// Builds and sends the actual http request. This reflects the guts of the
-// default Backbone.sync logic.
-//
-// @param {Function} method
-// @param {Object} model
-// @param {Object} options
-// @param {Function} resolve Deferred resolve
-// @param {Function} reject  Deferred reject
+  // DRY up success/error handling and HTTP sending request
+  var success = function(res) {
+    options.res = { headers: res.headers };
+    if (options.success) options.success(res.body);
+    if (options.complete) options.complete(res.body);
+    dfd.resolve(res.body); // TODO: This leaks memory
+  }
+  var error = function(err) {
+    if (options.error) options.error(err);
+    if (options.complete) options.complete(err);
+    dfd.reject(err); // TODO: This leaks memory
+  }
+  var send = function() {
+    request[METHOD_MAP[method]](url)
+      .send(method == 'create' || method == 'update' ? data : null)
+      .query(method == 'create' || method == 'update' ? null : data)
+      .set(options.headers || {})
+      .timeout(options.timeout || module.exports.timeout)
+      .end(function(err, res) {
+        if (err || !res.ok) return error(err || res);
+        // Save result in cache
+        if (options.cache && module.exports.cacheClient) {
+          module.exports.cacheClient.set(cacheKey, JSON.stringify({
+            body: res.body,
+            headers: res.headers
+          }));
+          module.exports.cacheClient.expire(cacheKey,
+            (options.cacheTime || module.exports.defaultCacheTime));
+        }
+        // Resolve success
+        success(res);
+      });
+  }
 
-var send = function (method, model, options, resolve, reject) {
-  var url = urlDataCacheKey(method, model, options)[0];
-  var data = urlDataCacheKey(method, model, options)[1];
-  var cacheKey = urlDataCacheKey(method, model, options)[2];
-
-  // Allow intercepting of the request object to inject sync-wide things like
-  // an oAuth token.
-  request[METHOD_MAP[method]](url)
-    .send(method == 'create' || method == 'update' ? data : null)
-    .query(method == 'create' || method == 'update' ? null : data)
-    .set(options.headers || {})
-    .timeout(options.timeout || module.exports.timeout)
-    .end(function(err, res) {
-      if (err || !res.ok) return error(options, (err || res), reject);
-      if (options.cache && module.exports.cacheClient) {
-        module.exports.cacheClient.set(cacheKey, JSON.stringify({
-          body: res.body,
-          headers: res.headers
-        }));
-        module.exports.cacheClient.expire(cacheKey,
-          (options.cacheTime || module.exports.defaultCacheTime));
+  // If cached, check cache—otherwise just send. Trigger request regardless
+  if (options.cache && module.exports.cacheClient) {
+    module.exports.cacheClient.get(cacheKey, function(err, cachedJSON) {
+      if (err) {
+        error(err);
+      } else if (cachedJSON) {
+        success(JSON.parse(cachedJSON));
+      } else {
+        send();
       }
-      success(options, res, resolve);
     });
-  model.trigger('request', model, {});
-}
+  } else {
+    send();
+  }
+  // model.trigger('request', model, {}, options);
 
-// DRYs up resolving the callbacks and deferreds for a successful response,
-// whether that's from the cache or a resolved http request.
-//
-// @param {Object} options Backbone options
-// @param {Object} res A response object with { body: {}, headers: {} }
-// @param {Function} resolve Deferred resolve
-
-var success = function(options, res, resolve) {
-  options.res = { headers: res.headers };
-  if (options.success) options.success(res.body);
-  if (options.complete) options.complete(res.body);
-  resolve(res.body);
-}
-
-// DRYs up resolving the callbacks and deferreds for an unsuccessful response,
-// whether that's from the cache or a resolved http request.
-//
-// @param {Object} options Backbone options
-// @param {Object} err
-// @param {Function} reject  Deferred reject
-
-var error = function(options, err, reject) {
-  if (options.error) options.error(err);
-  if (options.complete) options.complete(err);
-  reject(err);
-}
+  // Return promise and null out leaky vars
+  return dfd.promise.fin(function() {
+    dfd = null;
+    error = null;
+    success = null;
+    send = null;
+  });
+};
 
 // Configuration that can be overwritten by the user. Includes a optional
 // cache client library integration, default cache expiry, and
 // the default timeout for a sent http request.
-
 module.exports.cacheClient = null;
 module.exports.defaultCacheTime = 3600;
-module.exports.timeout = 2000;
+module.exports.timeout = 10000;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbone-super-sync",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Server-side Backbone.sync adapter using super agent.",
   "keywords": [
     "backbone",
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "superagent": "*",
-    "q": "*"
+    "bluebird": "*"
   },
   "devDependencies": {
     "mocha": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbone-super-sync",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Server-side Backbone.sync adapter using super agent.",
   "keywords": [
     "backbone",

--- a/test.js
+++ b/test.js
@@ -151,7 +151,7 @@ describe('Backbone Super Sync', function() {
 
     it('can error from promises', function (done) {
       model.url = 'http://localhost:5000/err'
-      model.fetch().then(function() {}, function() {
+      model.fetch().catch(function() {
         done()
       });
     });


### PR DESCRIPTION
Turns out this was most likely the memory leak culprit all along. Code refactored to be much simpler as well.